### PR TITLE
Added list fixtures command

### DIFF
--- a/Doctrine/Command/ListFixturesCommand.php
+++ b/Doctrine/Command/ListFixturesCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Doctrine\Command;
+
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface;
+use Hautelook\AliceBundle\Doctrine\DataFixtures\Executor\ORMExecutor;
+use Hautelook\AliceBundle\Doctrine\Finder\Finder;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * Command used to list the fixtures.
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class ListFixturesCommand extends Command
+{
+    /**
+     * @var Finder
+     */
+    private $finder;
+
+    /**
+     * @param Finder $finder
+     */
+    public function __construct(Finder $finder)
+    {
+        parent::__construct();
+
+        $this->finder = $finder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('hautelook_alice:fixtures:list')
+            ->setDescription('List registered fixtures.')
+            ->addOption(
+                'bundle',
+                'b',
+                InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY,
+                'Bundles where fixtures should be looked in'
+            )
+        ;
+        //TODO: set help
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * \RuntimeException Unsupported Application type
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var Application $application */
+        $application = $this->getApplication();
+        if (false === $application instanceof Application) {
+            throw new \RuntimeException('Expected Symfony\Bundle\FrameworkBundle\Console\Application application.');
+        }
+
+        // Get bundles
+        $bundles = $input->getOption('bundle');
+        if (true === empty($bundles)) {
+            $bundles = $application->getKernel()->getBundles();
+        } else {
+            $bundles = $this->finder->resolveBundles($application, $bundles);
+        }
+
+        // Get fixtures
+        $fixtures = $this->finder->getFixtures($application->getKernel(), $bundles, ucfirst($input->getOption('env')));
+        $output->writeln(sprintf('  <comment>></comment> <info>%s</info>', 'fixtures found:'));
+        foreach ($fixtures as $fixture) {
+            $output->writeln(sprintf('      <comment>-</comment> <info>%s</info>', $fixture));
+        }
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -31,6 +31,13 @@
 
         <service id="hautelook_alice.doctrine.finder" class="Hautelook\AliceBundle\Doctrine\Finder\Finder" />
 
+        <service id="hautelook_alice.doctrine.command.list_command"
+                 class="Hautelook\AliceBundle\Doctrine\Command\ListFixturesCommand"
+                 lazy="true">
+            <argument type="service" id="hautelook_alice.doctrine.finder" />
+            <tag name="console.command" />
+        </service>
+
         <service id="hautelook_alice.doctrine.command.load_command"
                  class="Hautelook\AliceBundle\Doctrine\Command\LoadDataFixturesCommand"
                  lazy="true">


### PR DESCRIPTION
Added the command `hautelook_alice:fixtures:list` that list all registered fixtures. Inspired from doctrine/DoctrineFixturesBundle#106.

Todo:
* [ ] Add tests
* [ ] Update documentation `h:f:l` will no longer be available as it will be ambigus

@hjr3 could you give me your opinion regarding this feature? I'm not sure of the implementation either, this could be an option `--list` of the current command rather than a new command.