### PR TITLE
Declared original finder as a service

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -29,6 +29,8 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
+        <service id="hautelook_alice.finder" class="Hautelook\AliceBundle\Doctrine\Finder\Finder" />
+
         <service id="hautelook_alice.doctrine.finder" class="Hautelook\AliceBundle\Doctrine\Finder\Finder" />
 
         <service id="hautelook_alice.doctrine.command.load_command"


### PR DESCRIPTION
Register `Hautelook\AliceBundle\Doctrine\Finder\Finder` as the service `hautelook_alice.finder`.