### PR TITLE
Fixed ignored files with Doctrine DataLoader

### DIFF
--- a/Doctrine/Finder/Finder.php
+++ b/Doctrine/Finder/Finder.php
@@ -38,7 +38,7 @@ class Finder extends \Hautelook\AliceBundle\Finder\Finder
         }
         
         // If no data loader is found, takes all fixtures files
-        if (0 === count($fixtures)) {
+        if (0 === count($loaders)) {
 
             return parent::getFixturesFromDirectory($path);
         }

--- a/Tests/Doctrine/Command/DoctrineFixtureTest.php
+++ b/Tests/Doctrine/Command/DoctrineFixtureTest.php
@@ -258,6 +258,41 @@ EOF
 EOF
         ];
 
+        $data[] = [
+            [
+                '--env'    => 'ignored',
+                '--bundle' => [
+                    'TestBundle',
+                ]
+            ],
+            <<<EOF
+              > fixtures found:
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
+  > purging database
+  > fixtures loaded
+
+EOF
+        ];
+
+        $data[] = [
+            [
+                '--env'    => 'ignored2',
+                '--bundle' => [
+                    'TestBundle',
+                ]
+            ],
+            <<<EOF
+              > fixtures found:
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored2/notIgnored.yml
+  > purging database
+  > fixtures loaded
+
+EOF
+        ];
+
         // Fix paths
         foreach ($data as $index => $dataSet) {
             $data[$index][1] = str_replace('/home/travis/build/theofidry/AliceBundle', getcwd(), $dataSet[1]);

--- a/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored/DataLoader.php
+++ b/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored/DataLoader.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\Ignored;
+
+use Hautelook\AliceBundle\Doctrine\DataFixtures\AbstractLoader;
+
+class DataLoader extends AbstractLoader
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFixtures()
+    {
+        return [];
+    }
+}

--- a/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored/ignored.yml
+++ b/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored/ignored.yml
@@ -1,0 +1,3 @@
+Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity\Brand:
+    brand{1..10}:
+        name: <testLoaderFormatter()>

--- a/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored2/DataLoader.php
+++ b/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored2/DataLoader.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\Ignored2;
+
+use Hautelook\AliceBundle\Doctrine\DataFixtures\AbstractLoader;
+
+class DataLoader extends AbstractLoader
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFixtures()
+    {
+        return [
+            __DIR__.'/notIgnored.yml',
+        ];
+    }
+}

--- a/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored2/ignored.yml
+++ b/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored2/ignored.yml
@@ -1,0 +1,3 @@
+Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity\Brand:
+    brand{1..10}:
+        name: <testLoaderFormatter()>

--- a/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored2/notIgnored.yml
+++ b/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Ignored2/notIgnored.yml
@@ -1,0 +1,3 @@
+Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity\Brand:
+    brand{1..10}:
+        name: Brand name


### PR DESCRIPTION
Previous behaviour was checking for the number of fixtures files returned by loaders, and if no fixtures were found, load all fixtures files from the directory. The expected behaviour is to check if there is any loader and if not all fixtures files from the directory should be taken.

This fix the following use case: putting one DataLoader in a directory which does not return any fixtures in order to ignore all fixtures files present in the directory.