### PR TITLE
Loaders as providers

### DIFF
--- a/Alice/DataFixtures/Loader.php
+++ b/Alice/DataFixtures/Loader.php
@@ -76,7 +76,7 @@ class Loader implements LoaderInterface
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getOptions()
     {
@@ -84,7 +84,7 @@ class Loader implements LoaderInterface
     }
 
     /**
-     * @return array|ProcessorInterface[]
+     * {@inheritdoc}
      */
     public function getProcessors()
     {

--- a/Alice/DataFixtures/LoaderInterface.php
+++ b/Alice/DataFixtures/LoaderInterface.php
@@ -29,4 +29,19 @@ interface LoaderInterface
      * @return \object[] Persisted objects
      */
     public function load($persister, array $fixtures);
+
+    /**
+     * @return array Options of Alice fixtures loader. Has the following keys:
+     *               - providers (array): Faker data providers
+     *               - locale (string): Faker locale used to select the data providers to use
+     *               - seed (int): seed used for the generation of random data by Faker
+     *               - persist_once (bool): option of Alice loader
+     *               - logger (\Psr\Log\LoggerInterface): logger used by Alice loader
+     */
+    public function getOptions();
+
+    /**
+     * @return array|ProcessorInterface[]
+     */
+    public function getProcessors();
 }

--- a/Doctrine/DataFixtures/AbstractLoader.php
+++ b/Doctrine/DataFixtures/AbstractLoader.php
@@ -31,6 +31,6 @@ abstract class AbstractLoader extends ContainerAware implements LoaderInterface
      */
     public function load(ObjectManager $objectManager)
     {
-        return $this->container->get('hautelook_alice.fixtures.loader')->load($objectManager, $this->getFixtures());
+        throw new \RuntimeException('This method was not expected to be called.');
     }
 }

--- a/Tests/Doctrine/Command/DoctrineFixtureTest.php
+++ b/Tests/Doctrine/Command/DoctrineFixtureTest.php
@@ -293,6 +293,24 @@ EOF
 EOF
         ];
 
+        $data[] = [
+            [
+                '--env'    => 'provider',
+                '--bundle' => [
+                    'TestBundle',
+                ]
+            ],
+            <<<EOF
+              > fixtures found:
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Provider/testFormatter.yml
+  > purging database
+  > fixtures loaded
+
+EOF
+        ];
+
         // Fix paths
         foreach ($data as $index => $dataSet) {
             $data[$index][1] = str_replace('/home/travis/build/theofidry/AliceBundle', getcwd(), $dataSet[1]);

--- a/Tests/Doctrine/Finder/FinderTest.php
+++ b/Tests/Doctrine/Finder/FinderTest.php
@@ -125,6 +125,31 @@ class FinderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @cover ::getDataLoaders
+     * @dataProvider dataLoadersProvider
+     */
+    public function testGetDataLoaders($bundles, $environment, $expected)
+    {
+        $finder = new Finder();
+
+        $loaders = $finder->getDataLoaders($bundles, $environment);
+
+        try {
+            foreach ($loaders as $index => $loader) {
+                $loaders[$index] = get_class($loader);
+            }
+            sort($expected);
+            sort($loaders);
+
+            $this->assertEquals($expected, $loaders);
+        } catch (\InvalidArgumentException $exception) {
+            if (0 !== count($expected)) {
+                throw $exception;
+            }
+        }
+    }
+
     public function fixturesProvider()
     {
         $return = [];
@@ -282,6 +307,42 @@ class FinderTest extends \PHPUnit_Framework_TestCase
                 );
             }
         }
+
+        return $return;
+    }
+
+    public function dataLoadersProvider()
+    {
+        $return = [];
+
+        $return[] = [
+            [
+                new TestBundle(),
+            ],
+            'dev',
+            [
+                'Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\DataLoader',
+            ]
+        ];
+
+        $return[] = [
+            [
+                new TestBundle(),
+            ],
+            'ignored',
+            [
+                'Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\DataLoader',
+                'Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\Ignored\DataLoader',
+            ]
+        ];
+
+        $return[] = [
+            [
+                new TestABundle(),
+            ],
+            'dev',
+            []
+        ];
 
         return $return;
     }

--- a/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Provider/DataLoader.php
+++ b/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Provider/DataLoader.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\Provider;
+
+use Hautelook\AliceBundle\Doctrine\DataFixtures\AbstractLoader;
+
+class DataLoader extends AbstractLoader
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFixtures()
+    {
+        return [
+            __DIR__.'/testFormatter.yml',
+        ];
+    }
+
+    public function testLoaderFormatter()
+    {
+        return 'a string';
+    }
+}

--- a/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Provider/testFormatter.yml
+++ b/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Provider/testFormatter.yml
@@ -1,0 +1,3 @@
+Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity\Brand:
+    brand{1..10}:
+        name: <testLoaderFormatter()>


### PR DESCRIPTION
As addressed in issue #81, data loaders are no longer took as providers. As a result, public methods of data loaders are no longer recognised as formatters.

To solve it, the Doctrine Finder now look for data loaders too and a new loader, taking the data loaders found as providers too, will be used in the command.