### PR TITLE
Refactor to break the extract the Command logic

### DIFF
--- a/Alice/DataFixtures/Fixtures/LoaderInterface.php
+++ b/Alice/DataFixtures/Fixtures/LoaderInterface.php
@@ -12,6 +12,8 @@
 namespace Hautelook\AliceBundle\Alice\DataFixtures\Fixtures;
 
 /**
+ * Loader responsible for loading fixtures files into objects.
+ *
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
 interface LoaderInterface

--- a/Alice/DataFixtures/Loader.php
+++ b/Alice/DataFixtures/Loader.php
@@ -61,8 +61,8 @@ class Loader implements LoaderInterface
     {
         if ($this->fixturesLoader instanceof FixturesLoader) {
             $_persister = $this->fixturesLoader->getPersister();
+            $this->fixturesLoader->setPersister($persister);
         }
-        $this->fixturesLoader->setPersister($persister);
 
         if (0 === count($fixtures)) {
             return [];

--- a/Alice/DataFixtures/LoaderInterface.php
+++ b/Alice/DataFixtures/LoaderInterface.php
@@ -15,7 +15,7 @@ use Nelmio\Alice\PersisterInterface;
 use Nelmio\Alice\ProcessorInterface;
 
 /**
- * The loader is class responsible for loading the fixtures.
+ * The loader is class responsible for loading the fixtures files into objects and persist them into the database.
  *
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */

--- a/Doctrine/Command/CommandFactory.php
+++ b/Doctrine/Command/CommandFactory.php
@@ -13,6 +13,9 @@ namespace Hautelook\AliceBundle\Doctrine\Command;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface;
+use Hautelook\AliceBundle\Doctrine\DataFixtures\Executor\FixturesExecutorInterface;
+use Hautelook\AliceBundle\Doctrine\Generator\LoaderGenerator;
+use Hautelook\AliceBundle\Doctrine\Generator\LoaderGeneratorInterface;
 use Hautelook\AliceBundle\Finder\FixturesFinderInterface;
 use Hautelook\AliceBundle\Resolver\BundlesResolverInterface;
 use Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\LoaderInterface as FixturesLoaderInterface;
@@ -25,30 +28,36 @@ use Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\LoaderInterface as Fixture
 class CommandFactory
 {
     /**
-     * @param string                   $name Command name
-     * @param ManagerRegistry          $doctrineRegistry
-     * @param LoaderInterface          $loader
-     * @param FixturesLoaderInterface  $fixturesLoader
-     * @param FixturesFinderInterface  $fixturesFinder
-     * @param BundlesResolverInterface $bundlesResolver
+     * @param string                    $name Command name
+     * @param ManagerRegistry           $doctrine
+     * @param LoaderInterface           $loader
+     * @param FixturesLoaderInterface   $fixturesLoader
+     * @param FixturesFinderInterface   $fixturesFinder
+     * @param BundlesResolverInterface  $bundlesResolver
+     * @param LoaderGeneratorInterface  $loaderGenerator
+     * @param FixturesExecutorInterface $fixturesExecutor
      *
      * @return LoadDataFixturesCommand
      */
     public function createCommand(
         $name,
-        ManagerRegistry $doctrineRegistry,
+        ManagerRegistry $doctrine,
         LoaderInterface $loader,
         FixturesLoaderInterface $fixturesLoader,
         FixturesFinderInterface $fixturesFinder,
-        BundlesResolverInterface $bundlesResolver
+        BundlesResolverInterface $bundlesResolver,
+        LoaderGeneratorInterface $loaderGenerator,
+        FixturesExecutorInterface $fixturesExecutor
     ) {
         return new LoadDataFixturesCommand(
             $name,
-            $doctrineRegistry,
+            $doctrine,
             $loader,
             $fixturesLoader,
             $fixturesFinder,
-            $bundlesResolver
+            $bundlesResolver,
+            $loaderGenerator,
+            $fixturesExecutor
         );
     }
 }

--- a/Doctrine/DataFixtures/Executor/ExecutorInterface.php
+++ b/Doctrine/DataFixtures/Executor/ExecutorInterface.php
@@ -35,8 +35,15 @@ interface ExecutorInterface
     /**
      * Executes the given array of data fixtures.
      *
-     * @param array $fixtures Array of fixtures to execute.
-     * @param boolean $append Whether to append the data fixtures or purge the database before loading.
+     * @param object[] $fixtures Array of fixtures to execute.
+     * @param boolean  $append   Whether to append the data fixtures or purge the database before loading.
      */
     public function execute(array $fixtures, $append = false);
+
+    /**
+     * Sets the logger callable to execute with the log() method.
+     *
+     * @param callable $logger
+     */
+    public function setLogger($logger);
 }

--- a/Doctrine/DataFixtures/Executor/ExecutorTrait.php
+++ b/Doctrine/DataFixtures/Executor/ExecutorTrait.php
@@ -18,8 +18,13 @@ trait ExecutorTrait
      * @param string[]          $fixtures Real path to fixtures files
      * @param bool              $append
      */
-    private function executeExecutor(ExecutorInterface $executor, ObjectManager $manager, LoaderInterface $loader, array $fixtures, $append = false)
-    {
+    private function executeExecutor(
+        ExecutorInterface $executor,
+        ObjectManager $manager,
+        LoaderInterface $loader,
+        array $fixtures,
+        $append = false
+    ) {
         $function = function (ObjectManager $manager) use ($executor, $loader, $fixtures, $append) {
             if (false === $append) {
                 $executor->purge();

--- a/Doctrine/DataFixtures/Executor/FixturesExecutor.php
+++ b/Doctrine/DataFixtures/Executor/FixturesExecutor.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Doctrine\DataFixtures\Executor;
+
+use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\MongoDB\DocumentManager as MongoDBDocumentManager;
+use Doctrine\ODM\PHPCR\DocumentManager as PHPCRDocumentManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class FixturesExecutor implements FixturesExecutorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(
+        ObjectManager $manager,
+        LoaderInterface $loader,
+        array $fixturesFiles,
+        $append,
+        $loggerCallable,
+        $truncate = false
+    ) {
+        // Get executor
+        $executor = $this->getExecutor($manager, $loader, $truncate);
+        $executor->setLogger($loggerCallable);
+
+        // Purge database and load fixtures
+        $executor->execute($fixturesFiles, $append);
+    }
+
+    /**
+     * Gets the executor for the matching the given object manager.
+     *
+     * @param ObjectManager   $manager
+     * @param LoaderInterface $loader
+     * @param bool|null       $purgeMode
+     *
+     * @return ExecutorInterface
+     */
+    private function getExecutor(ObjectManager $manager, LoaderInterface $loader, $purgeMode)
+    {
+        switch (true) {
+            case $manager instanceof EntityManagerInterface:
+                $executor = new ORMExecutor($manager, $loader);
+                $purger = new ORMPurger($manager);
+                $purger->setPurgeMode(
+                    $purgeMode
+                        ? ORMPurger::PURGE_MODE_TRUNCATE
+                        : ORMPurger::PURGE_MODE_DELETE
+                );
+                break;
+
+            case $manager instanceof MongoDBDocumentManager:
+                $executor = new MongoDBExecutor($manager, $loader);
+                $purger = new MongoDBPurger($manager);
+                break;
+
+            case $manager instanceof PHPCRDocumentManager:
+                $executor = new PHPCRExecutor($manager, $loader);
+                $purger = new PHPCRPurger($manager);
+                break;
+
+            default:
+                throw new \InvalidArgumentException(sprintf(
+                    'Unsupported manager type %s',
+                    get_class($manager))
+                );
+        }
+
+        $executor->setPurger($purger);
+
+        return $executor;
+    }
+}

--- a/Doctrine/DataFixtures/Executor/FixturesExecutorInterface.php
+++ b/Doctrine/DataFixtures/Executor/FixturesExecutorInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Doctrine\DataFixtures\Executor;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+interface FixturesExecutorInterface
+{
+    /**
+     * Executes the given array of data fixtures.
+     *
+     * @param ObjectManager   $manager
+     * @param LoaderInterface $loader
+     * @param string[]        $fixturesPath Fixtures real paths
+     * @param boolean         $append       If true append the loaded data otherwise purge the database before
+     * @param callable        $loggerCallable
+     * @param boolean         $truncate     The purge mode (truncate or delete).
+     *
+     * @return
+     */
+    public function execute(
+        ObjectManager $manager,
+        LoaderInterface $loader,
+        array $fixturesPath,
+        $append,
+        $loggerCallable,
+        $truncate = false
+    );
+}

--- a/Doctrine/DataFixtures/Executor/MongoDBExecutor.php
+++ b/Doctrine/DataFixtures/Executor/MongoDBExecutor.php
@@ -15,12 +15,10 @@ use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor as DoctrineMongoDBExec
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface;
-use Nelmio\Alice\Persister\Doctrine;
 
 /**
  * Class responsible for executing data fixtures.
  *
- * @author Jonathan H. Wage <jonwage@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
 class MongoDBExecutor extends DoctrineMongoDBExecutor implements ExecutorInterface

--- a/Doctrine/DataFixtures/Executor/ORMExecutor.php
+++ b/Doctrine/DataFixtures/Executor/ORMExecutor.php
@@ -20,7 +20,6 @@ use Nelmio\Alice\Persister\Doctrine;
 /**
  * Class responsible for executing data fixtures.
  *
- * @author Jonathan H. Wage <jonwage@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
 class ORMExecutor extends DoctrineORMExecutor implements ExecutorInterface

--- a/Doctrine/DataFixtures/Executor/PHPCRExecutor.php
+++ b/Doctrine/DataFixtures/Executor/PHPCRExecutor.php
@@ -13,16 +13,12 @@ namespace Hautelook\AliceBundle\Doctrine\DataFixtures\Executor;
 
 use Doctrine\Common\DataFixtures\Executor\PHPCRExecutor as DoctrinePHPCRExecutor;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface;
-use Nelmio\Alice\Persister\Doctrine;
 
 /**
  * Class responsible for executing data fixtures.
  *
- * @author Jonathan H. Wage <jonwage@gmail.com>
- * @author Daniel Barsotti <daniel.barsotti@liip.ch>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  */
 class PHPCRExecutor extends DoctrinePHPCRExecutor implements ExecutorInterface
@@ -38,6 +34,8 @@ class PHPCRExecutor extends DoctrinePHPCRExecutor implements ExecutorInterface
      * Construct new fixtures loader instance.
      *
      * @param DocumentManager $manager DocumentManager instance used for persistence.
+     * @param LoaderInterface $loader
+     * @param PHPCRPurger     $purger
      */
     public function __construct(DocumentManager $manager, LoaderInterface $loader, PHPCRPurger $purger = null)
     {

--- a/Doctrine/Generator/LoaderGenerator.php
+++ b/Doctrine/Generator/LoaderGenerator.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Doctrine\Generator;
+
+use Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\LoaderInterface as FixturesLoaderInterface;
+use Hautelook\AliceBundle\Alice\DataFixtures\Loader;
+use Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface;
+use Hautelook\AliceBundle\Doctrine\Finder\FixturesFinder;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class LoaderGenerator implements LoaderGeneratorInterface
+{
+    /**
+     * @var FixturesFinder
+     */
+    private $fixturesFinder;
+
+    /**
+     * @param FixturesFinder $fixturesFinder
+     */
+    public function __construct(FixturesFinder $fixturesFinder)
+    {
+        $this->fixturesFinder = $fixturesFinder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(
+        LoaderInterface $loader,
+        FixturesLoaderInterface $fixturesLoader,
+        array $bundles,
+        $environment
+    ) {
+        $doctrineDataLoaders = $this->fixturesFinder->getDataLoaders($bundles, $environment);
+
+        $_fixturesLoader = clone $fixturesLoader;
+        $_fixturesLoader->addProvider($doctrineDataLoaders);
+
+        return new Loader(
+            $_fixturesLoader,
+            $loader->getProcessors(),
+            $loader->getPersistOnce()
+        );
+    }
+}

--- a/Doctrine/Generator/LoaderGeneratorInterface.php
+++ b/Doctrine/Generator/LoaderGeneratorInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Doctrine\Generator;
+
+use Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\LoaderInterface as FixturesLoaderInterface;
+use Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+/**
+ * Class responsible to generate the loader to use for loading the fixtures and persisting them into the database.
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+interface LoaderGeneratorInterface
+{
+    /**
+     * Create a new loader using Doctrine data loaders as providers.
+     *
+     * @param LoaderInterface         $loader
+     * @param FixturesLoaderInterface $fixturesLoader
+     * @param BundleInterface[]       $bundles
+     * @param string                  $environment
+     *
+     * @return LoaderInterface
+     */
+    public function generate(
+        LoaderInterface $loader,
+        FixturesLoaderInterface $fixturesLoader,
+        array $bundles,
+        $environment
+    );
+}

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -20,6 +20,8 @@
             <argument type="service" id="hautelook_alice.alice.fixtures.loader" />
             <argument type="service" id="hautelook_alice.doctrine.mongodb.fixtures_finder" />
             <argument type="service" id="hautelook_alice.bundle_resolver" />
+            <argument type="service" id="hautelook_alice.doctrine.generator.loader_generator" />
+            <argument type="service" id="hautelook_alice.doctrine.executor.fixtures_executor" />
             <tag name="console.command" />
         </service>
     </services>

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -20,6 +20,8 @@
             <argument type="service" id="hautelook_alice.alice.fixtures.loader" />
             <argument type="service" id="hautelook_alice.doctrine.orm.fixtures_finder" />
             <argument type="service" id="hautelook_alice.bundle_resolver" />
+            <argument type="service" id="hautelook_alice.doctrine.generator.loader_generator" />
+            <argument type="service" id="hautelook_alice.doctrine.executor.fixtures_executor" />
             <tag name="console.command" />
         </service>
 
@@ -33,6 +35,8 @@
             <argument type="service" id="hautelook_alice.alice.fixtures.loader" />
             <argument type="service" id="hautelook_alice.doctrine.orm.fixtures_finder" />
             <argument type="service" id="hautelook_alice.bundle_resolver" />
+            <argument type="service" id="hautelook_alice.doctrine.generator.loader_generator" />
+            <argument type="service" id="hautelook_alice.doctrine.executor.fixtures_executor" />
             <tag name="console.command" />
         </service>
     </services>

--- a/Resources/config/phpcr.xml
+++ b/Resources/config/phpcr.xml
@@ -20,6 +20,8 @@
             <argument type="service" id="hautelook_alice.alice.fixtures.loader" />
             <argument type="service" id="hautelook_alice.doctrine.phpcr.fixtures_finder" />
             <argument type="service" id="hautelook_alice.bundle_resolver" />
+            <argument type="service" id="hautelook_alice.doctrine.generator.loader_generator" />
+            <argument type="service" id="hautelook_alice.doctrine.executor.fixtures_executor" />
             <tag name="console.command" />
         </service>
     </services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -21,6 +21,15 @@
                  class="Hautelook\AliceBundle\Faker\Provider\ProviderChain"
                  lazy="true" />
 
+        <service id="hautelook_alice.doctrine.executor.fixtures_executor"
+                 class="Hautelook\AliceBundle\Doctrine\DataFixtures\Executor\FixturesExecutor"
+                 lazy="true" />
+
+        <service id="hautelook_alice.doctrine.generator.loader_generator"
+                 class="Hautelook\AliceBundle\Doctrine\Generator\LoaderGenerator">
+            <argument type="service" id="hautelook_alice.doctrine.orm.fixtures_finder" />
+        </service>
+
         <service id="hautelook_alice.alice.fixtures.loader"
                  class="Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\Loader">
             <argument>%hautelook_alice.locale%</argument>

--- a/Tests/Alice/DataFixtures/LoaderTest.php
+++ b/Tests/Alice/DataFixtures/LoaderTest.php
@@ -181,4 +181,20 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([$object], $objects);
     }
+
+    public function testLoaderInterface()
+    {
+        $object = new \stdClass();
+
+        $persisterProphecy = $this->prophesize('Nelmio\Alice\PersisterInterface');
+        $persisterProphecy->persist([$object])->shouldBeCalled();
+
+        $fixturesLoaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\LoaderInterface');
+        $fixturesLoaderProphecy->load('random/file')->willReturn([$object]);
+
+        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false);
+        $objects = $loader->load($persisterProphecy->reveal(), ['random/file']);
+
+        $this->assertEquals([$object], $objects);
+    }
 }

--- a/Tests/DependencyInjection/HautelookAliceExtensionTest.php
+++ b/Tests/DependencyInjection/HautelookAliceExtensionTest.php
@@ -420,6 +420,14 @@ class HautelookAliceExtensionTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalled()
         ;
         $containerBuilderProphecy
+            ->setDefinition('hautelook_alice.doctrine.executor.fixtures_executor', HautelookAliceBundleArgument::definition('Hautelook\AliceBundle\Doctrine\DataFixtures\Executor\FixturesExecutor'))
+            ->shouldBeCalled()
+        ;
+        $containerBuilderProphecy
+            ->setDefinition('hautelook_alice.doctrine.generator.loader_generator', HautelookAliceBundleArgument::definition('Hautelook\AliceBundle\Doctrine\Generator\LoaderGenerator'))
+            ->shouldBeCalled()
+        ;
+        $containerBuilderProphecy
             ->setDefinition('hautelook_alice.faker', HautelookAliceBundleArgument::definition('Faker\Generator'))
             ->shouldBeCalled()
         ;

--- a/Tests/Doctrine/DataFixtures/Executor/FixturesExecutorTest.php
+++ b/Tests/Doctrine/DataFixtures/Executor/FixturesExecutorTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Tests\Doctrine\DataFixtures\Executor;
+
+use Hautelook\AliceBundle\Doctrine\DataFixtures\Executor\FixturesExecutor;
+use Prophecy\Argument;
+
+/**
+ * @coversDefaultClass Hautelook\AliceBundle\Doctrine\DataFixtures\FixturesExecutor
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class FixturesExecutorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @cover ::execute
+     * @cover ::getExecutor
+     */
+    public function testExecuteWithoutTruncate()
+    {
+        $fixtures = ['fixture1'];
+
+        $objectManagerProphecy = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+
+        $eventManagerProphecy = $this->prophesize('Doctrine\Common\EventManager');
+        $eventManagerProphecy->addEventSubscriber(Argument::any())->will(
+            function ($args) {
+                return 'Doctrine\Common\DataFixtures\Event\Listener\ORMReferenceListener' === get_class($args[0]);
+            }
+        );
+        $eventManagerProphecy->addEventSubscriber(Argument::any())->will(
+            function ($args) {
+                return 'Doctrine\Common\DataFixtures\Event\Listener\MongoDBReferenceListener' === get_class($args[0]);
+            }
+        );
+
+        $entityManagerProphecy = $this->prophesize('Doctrine\ORM\EntityManagerInterface');
+        $entityManagerProphecy->getEventManager()->willReturn($eventManagerProphecy->reveal());
+        $entityManagerProphecy->transactional(Argument::any())->shouldBeCalledTimes(1);
+
+        $mongodbDocumentManagerProphecy = $this->prophesize('Doctrine\ODM\MongoDB\DocumentManager');
+        $mongodbDocumentManagerProphecy->getEventManager()->willReturn($eventManagerProphecy->reveal());
+
+        $phpcrDocumentManagerProphecy = $this->prophesize('Doctrine\ODM\PHPCR\DocumentManager');
+
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $loaderProphecy->load(Argument::any(), $fixtures)->will(
+            function ($arg1) {
+                return 'Nelmio\Alice\Persister\Doctrine' === get_class($arg1[0]);
+            }
+        );
+
+        $loggerProphecy = $this->prophesize('callable');
+
+        $fixturesExecutor = new FixturesExecutor();
+
+        try {
+            $fixturesExecutor->execute(
+                $objectManagerProphecy->reveal(),
+                $loaderProphecy->reveal(),
+                $fixtures,
+                $loggerProphecy->reveal(),
+                false
+            );
+            $this->fail('Expected \InvalidArgumentException to be thrown.');
+        } catch (\InvalidArgumentException $exception) {
+            // Expected result
+        }
+
+        $fixturesExecutor->execute(
+            $entityManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $fixtures,
+            $loggerProphecy->reveal(),
+            false
+        );
+
+        $fixturesExecutor->execute(
+            $mongodbDocumentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $fixtures,
+            $loggerProphecy->reveal(),
+            false
+        );
+
+        $fixturesExecutor->execute(
+            $phpcrDocumentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $fixtures,
+            $loggerProphecy->reveal(),
+            false
+        );
+    }
+
+    /**
+     * @cover ::execute
+     * @cover ::getExecutor
+     */
+    public function testExecuteWithTruncate()
+    {
+        $fixtures = ['fixture1'];
+
+        $objectManagerProphecy = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+
+        $eventManagerProphecy = $this->prophesize('Doctrine\Common\EventManager');
+        $eventManagerProphecy->addEventSubscriber(Argument::any())->will(
+            function ($args) {
+                return 'Doctrine\Common\DataFixtures\Event\Listener\ORMReferenceListener' === get_class($args[0]);
+            }
+        );
+        $eventManagerProphecy->addEventSubscriber(Argument::any())->will(
+            function ($args) {
+                return 'Doctrine\Common\DataFixtures\Event\Listener\MongoDBReferenceListener' === get_class($args[0]);
+            }
+        );
+
+        $entityManagerProphecy = $this->prophesize('Doctrine\ORM\EntityManagerInterface');
+        $entityManagerProphecy->getEventManager()->willReturn($eventManagerProphecy->reveal());
+        $entityManagerProphecy->transactional(Argument::any())->shouldBeCalledTimes(1);
+
+        $mongodbDocumentManagerProphecy = $this->prophesize('Doctrine\ODM\MongoDB\DocumentManager');
+        $mongodbDocumentManagerProphecy->getEventManager()->willReturn($eventManagerProphecy->reveal());
+
+        $phpcrDocumentManagerProphecy = $this->prophesize('Doctrine\ODM\PHPCR\DocumentManager');
+
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $loaderProphecy->load(Argument::any(), $fixtures)->will(
+            function ($arg1) {
+                return 'Nelmio\Alice\Persister\Doctrine' === get_class($arg1[0]);
+            }
+        );
+
+        $loggerProphecy = $this->prophesize('callable');
+
+        $fixturesExecutor = new FixturesExecutor();
+
+        try {
+            $fixturesExecutor->execute(
+                $objectManagerProphecy->reveal(),
+                $loaderProphecy->reveal(),
+                $fixtures,
+                $loggerProphecy->reveal(),
+                true
+            );
+            $this->fail('Expected \InvalidArgumentException to be thrown.');
+        } catch (\InvalidArgumentException $exception) {
+            // Expected result
+        }
+
+        $fixturesExecutor->execute(
+            $entityManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $fixtures,
+            $loggerProphecy->reveal(),
+            true
+        );
+
+        $fixturesExecutor->execute(
+            $mongodbDocumentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $fixtures,
+            $loggerProphecy->reveal(),
+            true
+        );
+
+        $fixturesExecutor->execute(
+            $phpcrDocumentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $fixtures,
+            $loggerProphecy->reveal(),
+            true
+        );
+    }
+}

--- a/Tests/Doctrine/DataFixtures/Executor/MongoDBExecutorTest.php
+++ b/Tests/Doctrine/DataFixtures/Executor/MongoDBExecutorTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Tests\Doctrine\DataFixtures\Executor;
+
+use Hautelook\AliceBundle\Doctrine\DataFixtures\Executor\MongoDBExecutor;
+use Nelmio\Alice\Persister\Doctrine;
+use Prophecy\Argument;
+
+/**
+ * @coversDefaultClass Hautelook\AliceBundle\Doctrine\DataFixtures\MongoDBExecutor
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class MongoDBExecutorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @cover ::__construct
+     */
+    public function testConstructor()
+    {
+        $eventManagerProphecy = $this->prophesize('Doctrine\Common\EventManager');
+        $eventManagerProphecy->addEventSubscriber(Argument::any())->will(
+            function ($args) {
+                return 'Doctrine\Common\DataFixtures\Event\Listener\MongoDBReferenceListener' === get_class($args[0]);
+            }
+        );
+
+        $documentManagerProphecy = $this->prophesize('Doctrine\ODM\MongoDB\DocumentManager');
+        $documentManagerProphecy->getEventManager()->willReturn($eventManagerProphecy->reveal());
+
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $purgerProphecy = $this->prophesize('Doctrine\Common\DataFixtures\Purger\MongoDBPurger');
+
+        new MongoDBExecutor(
+            $documentManagerProphecy->reveal(),
+            $loaderProphecy->reveal()
+        );
+
+        new MongoDBExecutor(
+            $documentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $purgerProphecy->reveal()
+        );
+    }
+
+    /**
+     * @cover ::execute
+     */
+    public function testExecutorWithAppend()
+    {
+        $fixtures = ['fixture1'];
+
+        $eventManagerProphecy = $this->prophesize('Doctrine\Common\EventManager');
+        $eventManagerProphecy->addEventSubscriber(Argument::any())->will(
+            function ($args) {
+                return 'Doctrine\Common\DataFixtures\Event\Listener\MongoDBReferenceListener' === get_class($args[0]);
+            }
+        );
+
+        $documentManagerProphecy = $this->prophesize('Doctrine\ODM\MongoDB\DocumentManager');
+        $documentManagerProphecy->getEventManager()->willReturn($eventManagerProphecy->reveal());
+
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $loaderProphecy->load(new Doctrine($documentManagerProphecy->reveal()), $fixtures);
+
+        $purgerProphecy = $this->prophesize('Doctrine\Common\DataFixtures\Purger\MongoDBPurger');
+        $purgerProphecy->setDocumentManager($documentManagerProphecy->reveal())->shouldBeCalled();
+        $purgerProphecy->purge()->shouldNotBeCalled();
+
+        $executor = new MongoDBExecutor(
+            $documentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $purgerProphecy->reveal()
+        );
+
+        $executor->execute($fixtures, true);
+    }
+
+    /**
+     * @cover ::execute
+     */
+    public function testExecutorWithoutAppend()
+    {
+        $fixtures = ['fixture1'];
+
+        $eventManagerProphecy = $this->prophesize('Doctrine\Common\EventManager');
+        $eventManagerProphecy->addEventSubscriber(Argument::any())->will(
+            function ($args) {
+                return 'Doctrine\Common\DataFixtures\Event\Listener\MongoDBReferenceListener' === get_class($args[0]);
+            }
+        );
+
+        $documentManagerProphecy = $this->prophesize('Doctrine\ODM\MongoDB\DocumentManager');
+        $documentManagerProphecy->getEventManager()->willReturn($eventManagerProphecy->reveal());
+
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $loaderProphecy->load(new Doctrine($documentManagerProphecy->reveal()), $fixtures);
+
+        $purgerProphecy = $this->prophesize('Doctrine\Common\DataFixtures\Purger\MongoDBPurger');
+        $purgerProphecy->setDocumentManager($documentManagerProphecy->reveal())->shouldBeCalled();
+        $purgerProphecy->purge()->shouldBeCalled();
+
+        $executor = new MongoDBExecutor(
+            $documentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $purgerProphecy->reveal()
+        );
+
+        $executor->execute($fixtures);
+    }
+}

--- a/Tests/Doctrine/DataFixtures/Executor/PHPCRExecutorTest.php
+++ b/Tests/Doctrine/DataFixtures/Executor/PHPCRExecutorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Tests\Doctrine\DataFixtures\Executor;
+
+use Hautelook\AliceBundle\Doctrine\DataFixtures\Executor\PHPCRExecutor;
+use Nelmio\Alice\Persister\Doctrine;
+
+/**
+ * @coversDefaultClass Hautelook\AliceBundle\Doctrine\DataFixtures\PHPCRExecutor
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class PHPCRExecutorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @cover ::__construct
+     */
+    public function testConstructor()
+    {
+        $documentManagerProphecy = $this->prophesize('Doctrine\ODM\PHPCR\DocumentManager');
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $purgerProphecy = $this->prophesize('Doctrine\Common\DataFixtures\Purger\PHPCRPurger');
+
+        new PHPCRExecutor(
+            $documentManagerProphecy->reveal(),
+            $loaderProphecy->reveal()
+        );
+
+        new PHPCRExecutor(
+            $documentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $purgerProphecy->reveal()
+        );
+    }
+
+    /**
+     * @cover ::execute
+     */
+    public function testExecutorWithAppend()
+    {
+        $fixtures = ['fixture1'];
+
+        $documentManagerProphecy = $this->prophesize('Doctrine\ODM\PHPCR\DocumentManager');
+
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $loaderProphecy->load(new Doctrine($documentManagerProphecy->reveal()), $fixtures);
+
+        $purgerProphecy = $this->prophesize('Doctrine\Common\DataFixtures\Purger\PHPCRPurger');
+        $purgerProphecy->setDocumentManager($documentManagerProphecy->reveal())->shouldBeCalled();
+        $purgerProphecy->purge()->shouldNotBeCalled();
+
+        $executor = new PHPCRExecutor(
+            $documentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $purgerProphecy->reveal()
+        );
+
+        $executor->execute($fixtures, true);
+    }
+
+    /**
+     * @cover ::execute
+     */
+    public function testExecutorWithoutAppend()
+    {
+        $fixtures = ['fixture1'];
+
+        $documentManagerProphecy = $this->prophesize('Doctrine\ODM\PHPCR\DocumentManager');
+
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $loaderProphecy->load(new Doctrine($documentManagerProphecy->reveal()), $fixtures);
+
+        $purgerProphecy = $this->prophesize('Doctrine\Common\DataFixtures\Purger\PHPCRPurger');
+        $purgerProphecy->setDocumentManager($documentManagerProphecy->reveal())->shouldBeCalled();
+        $purgerProphecy->purge()->shouldBeCalled();
+
+        $executor = new PHPCRExecutor(
+            $documentManagerProphecy->reveal(),
+            $loaderProphecy->reveal(),
+            $purgerProphecy->reveal()
+        );
+
+        $executor->execute($fixtures);
+    }
+}

--- a/Tests/Doctrine/Generator/GeneratorTest.php
+++ b/Tests/Doctrine/Generator/GeneratorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Tests\Doctrine;
+
+use Hautelook\AliceBundle\Doctrine\DataFixtures\Executor\FixturesExecutor;
+use Hautelook\AliceBundle\Doctrine\Generator\LoaderGenerator;
+use Prophecy\Argument;
+
+/**
+ * @coversDefaultClass Hautelook\AliceBundle\Doctrine\Generator
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class GeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @cover ::__construct
+     */
+    public function testConstruct()
+    {
+        $fixturesFinderProphecy = $this->prophesize('Hautelook\AliceBundle\Doctrine\Finder\FixturesFinder');
+
+        new LoaderGenerator($fixturesFinderProphecy->reveal());
+    }
+
+    /**
+     * @cover ::generate
+     */
+    public function testGenerate()
+    {
+        $dataloaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+
+        $processorProphecy = $this->prophesize('Nelmio\Alice\ProcessorInterface');
+        $processorProphecy->preProcess('fixtureObject');
+        $processorProphecy->postProcess('fixtureObject');
+
+        $bundleProphecy = $this->prophesize('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+
+        $fixturesFinderProphecy = $this->prophesize('Hautelook\AliceBundle\Doctrine\Finder\FixturesFinder');
+        $fixturesFinderProphecy
+            ->getDataLoaders([$bundleProphecy->reveal()], 'dev')
+            ->willReturn([$dataloaderProphecy->reveal()])
+        ;
+
+        $fixturesLoaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\LoaderInterface');
+        $fixturesLoaderProphecy->addProvider([$dataloaderProphecy->reveal()])->shouldBeCalled();
+        $fixturesLoaderProphecy->load('fixtureFile')->willReturn(['fixtureObject']);
+
+        $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $loaderProphecy->getProcessors()->willReturn([$processorProphecy->reveal()]);
+        $loaderProphecy->getPersistOnce()->willReturn(true);
+
+        $persisterProphecy = $this->prophesize('Nelmio\Alice\PersisterInterface');
+        $persisterProphecy->persist(['fixtureObject'])->shouldBeCalled();
+        $persister = $persisterProphecy->reveal();
+
+        $loaderGenerator = new LoaderGenerator($fixturesFinderProphecy->reveal());
+        $loader = $loaderGenerator->generate(
+            $loaderProphecy->reveal(),
+            $fixturesLoaderProphecy->reveal(),
+            [$bundleProphecy->reveal()],
+            'dev'
+        );
+
+        $this->assertEquals([$processorProphecy->reveal()], $loader->getProcessors());
+        $this->assertTrue($loader->getPersistOnce());
+
+        $loader->load($persister, ['fixtureFile']);
+    }
+}

--- a/Tests/Finder/FixturesFinderTest.php
+++ b/Tests/Finder/FixturesFinderTest.php
@@ -373,6 +373,14 @@ class FixturesFinderTest extends KernelTestCase
             []
         ];
 
+        // Non string or SqlInfo instance
+        $data[] = [
+            [
+                new \stdClass(),
+            ],
+            []
+        ];
+
 
         // Fix paths
         foreach ($data as $index => $dataSet) {

--- a/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
+++ b/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
@@ -3,4 +3,4 @@ parameters:
 
 Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity\Brand:
     brand{1..10}:
-        name: Brand <{hautelook_alice.locale}> <foo(%framework.secret%)> <name()> <{test_app.random}> <{custom}>
+        name: Brand <{hautelook_alice.locale}> <foo(<{custom}>)> <name()> <{test_app.random}>


### PR DESCRIPTION
As of now the Command creates a new application instance then looks
for all fixtures files, get the good loader for loading the fixtures
files and then get the Doctrine extractor depending of the database.

This is too much logic put on the Command component, it is very hard
to test it in a predictable way. As a result, this PR splits the
Command component into smaller bits, that may be reusable to
third-party libraries too.