### PR TITLE
Fix displays and arrays comparisons

### DIFF
--- a/Doctrine/Finder/FixturesFinder.php
+++ b/Doctrine/Finder/FixturesFinder.php
@@ -96,7 +96,7 @@ class FixturesFinder extends \Hautelook\AliceBundle\Finder\FixturesFinder
 
             if (true === isset($phpClasses[$sourceFile])) {
                 if ($reflectionClass->implementsInterface('Hautelook\AliceBundle\Doctrine\DataFixtures\LoaderInterface')) {
-                    $loaders[] = new $className;
+                    $loaders[$className] = new $className;
                 }
             }
         }

--- a/Finder/FixturesFinder.php
+++ b/Finder/FixturesFinder.php
@@ -54,6 +54,7 @@ class FixturesFinder implements FixturesFinderInterface
         }
 
         // Get real fixtures path
+        // Note: Fixtures returned are guaranteed to be unique here
         return $this->resolveFixtures($kernel, $fixtures);
     }
 

--- a/Tests/Doctrine/Command/CommandTestCase.php
+++ b/Tests/Doctrine/Command/CommandTestCase.php
@@ -52,4 +52,32 @@ class CommandTestCase extends KernelTestCase
         $options = array_merge($options, ['command' => $command]);
         return $this->application->run(new ArrayInput($options));
     }
+
+    /**
+     * @param string $expected
+     * @param string $display
+     */
+    protected function assertFixturesDisplayEquals($expected, $display)
+    {
+        $expected = $this->normalizeFixturesDisplay($expected);
+        $display = $this->normalizeFixturesDisplay($display);
+
+        $this->assertCount(0, array_diff($expected, $display));
+    }
+
+    /**
+     * @param string $display
+     *
+     * @return string[]
+     */
+    private function normalizeFixturesDisplay($display)
+    {
+        $display = trim($display, ' ');
+        $display = trim($display, "\t");
+        $display = preg_replace('/\n/', '', $display);
+        $display = explode("  > loading ", $display);
+        array_shift($display);
+
+        return $display;
+    }
 }

--- a/Tests/Doctrine/Command/DoctrineDataFixturesCommandsTest.php
+++ b/Tests/Doctrine/Command/DoctrineDataFixturesCommandsTest.php
@@ -41,19 +41,19 @@ class DoctrineDataFixturesCommandsTest extends CommandTestCase
 
         $expected = <<<EOF
               > purging database
+  > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\DataLoader
   > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\Ignored\DataLoader
   > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\Ignored2\DataLoader
   > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\Provider\DataLoader
-  > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\DataFixtures\ORM\DataLoader
+  > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Bundle\CBundle\DataFixtures\ORM\DataLoader
   > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Bundle\CBundle\DataFixtures\ORM\AEnv\DataLoader
   > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Bundle\CBundle\DataFixtures\ORM\BEnv\DataLoader
   > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Bundle\CBundle\DataFixtures\ORM\DEnv\DataLoader
   > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Bundle\CBundle\DataFixtures\ORM\EEnv\DataLoader
-  > loading Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Bundle\CBundle\DataFixtures\ORM\DataLoader
 
 EOF;
 
-        $this->assertEquals(trim($expected,' '), trim($commandTester->getDisplay(), ' '));
+        $this->assertFixturesDisplayEquals($expected, $commandTester->getDisplay());
     }
 
     public function testDoctrineODM()

--- a/Tests/Doctrine/Command/DoctrineODMFixturesTest.php
+++ b/Tests/Doctrine/Command/DoctrineODMFixturesTest.php
@@ -59,7 +59,7 @@ class DoctrineODMFixturesTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute($inputs, ['interactive' => false]);
 
-        $this->assertEquals(trim($expected,' '), trim($commandTester->getDisplay(), ' '));
+        $this->assertFixturesDisplayEquals($expected, $commandTester->getDisplay());
     }
 
     private function verifyProducts()

--- a/Tests/Doctrine/Command/DoctrineORMFixturesTest.php
+++ b/Tests/Doctrine/Command/DoctrineORMFixturesTest.php
@@ -63,7 +63,7 @@ class DoctrineORMFixturesTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute($inputs, ['interactive' => false]);
 
-        $this->assertEquals(trim($expected,' '), trim($commandTester->getDisplay(), ' '));
+        $this->assertFixturesDisplayEquals($expected, $commandTester->getDisplay());
     }
 
     private function verifyProducts()
@@ -153,11 +153,11 @@ EOF
             ],
             <<<EOF
               > fixtures found:
-      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
-      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
-      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Prod/prod.yml
       - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/Bundle/ABundle/DataFixtures/ORM/aentity.yml
       - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/Bundle/BBundle/DataFixtures/ORM/bentity.yml
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Prod/prod.yml
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
+      - /home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
   > purging database
   > fixtures loaded
 

--- a/Tests/Doctrine/Command/DoctrinePHPCRFixturesTest.php
+++ b/Tests/Doctrine/Command/DoctrinePHPCRFixturesTest.php
@@ -61,7 +61,7 @@ class DoctrinePHPCRFixturesTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute($inputs, ['interactive' => false]);
 
-        $this->assertEquals(trim($expected,' '), trim($commandTester->getDisplay(), ' '));
+        $this->assertFixturesDisplayEquals($expected, $commandTester->getDisplay());
     }
 
     private function verifyProducts()

--- a/Tests/Doctrine/Finder/FixturesFinderTest.php
+++ b/Tests/Doctrine/Finder/FixturesFinderTest.php
@@ -51,10 +51,7 @@ class FixturesFinderTest extends \PHPUnit_Framework_TestCase
         try {
             $fixtures = $finder->getFixtures($kernel->reveal(), $bundles, $environment);
 
-            sort($expected);
-            sort($fixtures);
-
-            $this->assertEquals($expected, $fixtures);
+            $this->assertCount(0, array_diff($expected, $fixtures));
         } catch (\InvalidArgumentException $exception) {
             if (0 !== count($expected)) {
                 throw $exception;
@@ -92,10 +89,8 @@ class FixturesFinderTest extends \PHPUnit_Framework_TestCase
             foreach ($loaders as $index => $loader) {
                 $loaders[$index] = get_class($loader);
             }
-            sort($expected);
-            sort($loaders);
 
-            $this->assertEquals($expected, $loaders);
+            $this->assertCount(0, array_diff($expected, $loaders));
         } catch (\InvalidArgumentException $exception) {
             if (0 !== count($expected)) {
                 throw $exception;

--- a/Tests/Finder/FixturesFinderTest.php
+++ b/Tests/Finder/FixturesFinderTest.php
@@ -52,9 +52,7 @@ class FixturesFinderTest extends KernelTestCase
         try {
             $fixtures = $finder->getFixtures($kernelProphecy->reveal(), $bundles, $environment);
 
-            sort($expected);
-            sort($fixtures);
-            $this->assertEquals($expected, $fixtures);
+            $this->assertCount(0, array_diff($expected, $fixtures));
         } catch (\InvalidArgumentException $exception) {
             if (0 !== count($expected)) {
                 throw $exception;
@@ -135,9 +133,9 @@ class FixturesFinderTest extends KernelTestCase
             'dev',
             [
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml',
-                '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Dev/dev.yml',
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/dummy.yml',
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml',
+                '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Dev/dev.yml',
             ]
         ];
 
@@ -148,9 +146,9 @@ class FixturesFinderTest extends KernelTestCase
             'Dev',
             [
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml',
-                '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Dev/dev.yml',
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/dummy.yml',
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml',
+                '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Dev/dev.yml',
             ]
         ];
 
@@ -162,8 +160,8 @@ class FixturesFinderTest extends KernelTestCase
             [
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml',
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/dummy.yml',
-                '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Inte/inte.yml',
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml',
+                '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Inte/inte.yml',
             ]
         ];
 
@@ -175,8 +173,8 @@ class FixturesFinderTest extends KernelTestCase
             [
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml',
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/dummy.yml',
-                '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Prod/prod.yml',
                 '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml',
+                '/home/travis/build/theofidry/AliceBundle/Tests/SymfonyApp/TestBundle/DataFixtures/ORM/Prod/prod.yml',
             ]
         ];
 


### PR DESCRIPTION
Now compares arrays of fixtures files or displays without taking into account the order. This avoid random failures due to files that are not loaded in the same order depending of the machine or environment.