### PR TITLE
Loading limit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ hautelook_alice:
     locale: en_US       # Locale to used for faker; must be a valid Faker locale otherwise will fallback to en_EN
     seed: 1             # A seed to make sure faker generates data consistently across runs, set to null to disable
     persist_once: false # Only persist objects once if multiple files are passed
+    loading_limit: 5    # Maximum number of time the loader will try to load the files passed
 ```
 
 Fore more information regarding the locale, refer to

--- a/src/Alice/DataFixtures/Loader.php
+++ b/src/Alice/DataFixtures/Loader.php
@@ -42,35 +42,24 @@ class Loader implements LoaderInterface
     /**
      * @var int
      */
-    private $loadingLimit = 5;
+    private $loadingLimit;
 
     /**
      * @param FixturesLoaderInterface $fixturesLoader
      * @param ProcessorInterface[]    $processors
      * @param bool                    $persistOnce
+     * @param int                     $loadingLimit
      */
     public function __construct(
         FixturesLoaderInterface $fixturesLoader,
         array $processors,
-        $persistOnce
+        $persistOnce,
+        $loadingLimit
     ) {
         $this->fixturesLoader = $fixturesLoader;
         $this->processors = $processors;
         $this->persistOnce = $persistOnce;
-    }
-
-    /**
-     * Sets load file limit, which is the maximum number of time the loader will try to load the files passed.
-     *
-     * @param int $loadingLimit
-     *
-     * @return $this
-     */
-    public function setLoadingLimit($loadingLimit)
-    {
         $this->loadingLimit = $loadingLimit;
-
-        return $this;
     }
 
     /**
@@ -130,6 +119,14 @@ class Loader implements LoaderInterface
     public function getPersistOnce()
     {
         return $this->persistOnce;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLoadingLimit()
+    {
+        return $this->loadingLimit;
     }
 
     private function areAllFixturesLoaded(array $normalizedFixturesFiles)

--- a/src/Alice/DataFixtures/LoaderInterface.php
+++ b/src/Alice/DataFixtures/LoaderInterface.php
@@ -40,4 +40,9 @@ interface LoaderInterface
      * @return bool If true only persist once the objects loaded.
      */
     public function getPersistOnce();
+
+    /**
+     * @return int Maximum number of time the loader will try to load the files passed
+     */
+    public function getLoadingLimit();
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -63,6 +63,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(false)
                     ->info('Only persist objects once if multiple files are passed')
                 ->end()
+                ->scalarNode('loading_limit')
+                    ->defaultValue(5)
+                    ->info('Maximum number of time the loader will try to load the files passed')
+                ->end()
             ->end()
         ;
 

--- a/src/Doctrine/Generator/LoaderGenerator.php
+++ b/src/Doctrine/Generator/LoaderGenerator.php
@@ -51,7 +51,8 @@ class LoaderGenerator implements LoaderGeneratorInterface
         return new Loader(
             $_fixturesLoader,
             $loader->getProcessors(),
-            $loader->getPersistOnce()
+            $loader->getPersistOnce(),
+            $loader->getLoadingLimit()
         );
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -40,6 +40,7 @@
             <argument type="service" id="hautelook_alice.alice.fixtures.loader" />
             <argument type="expression">service('hautelook_alice.alice.processor_chain').getProcessors()</argument>
             <argument>%hautelook_alice.persist_once%</argument>
+            <argument>%hautelook_alice.loading_limit%</argument>
         </service>
 
         <service id="hautelook_alice.bundle_resolver" class="Hautelook\AliceBundle\Resolver\BundlesResolver" />

--- a/tests/Alice/DataFixtures/LoaderTest.php
+++ b/tests/Alice/DataFixtures/LoaderTest.php
@@ -28,7 +28,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
     {
         $aliceLoaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\Loader');
 
-        $loader = new Loader($aliceLoaderProphecy->reveal(), ['dummyProcessor'], false);
+        $loader = new Loader($aliceLoaderProphecy->reveal(), ['dummyProcessor'], false, 5);
 
         $this->assertEquals(['dummyProcessor'], $loader->getProcessors());
         $this->assertFalse($loader->getPersistOnce());
@@ -36,7 +36,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
 
         $aliceLoaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\Loader');
 
-        $loader = new Loader($aliceLoaderProphecy->reveal(), [], true);
+        $loader = new Loader($aliceLoaderProphecy->reveal(), [], true, 5);
 
         $this->assertEquals([], $loader->getProcessors());
         $this->assertTrue($loader->getPersistOnce());
@@ -51,8 +51,8 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $aliceLoaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\Loader');
 
         $persisterProphecy = $this->prophesize('Nelmio\Alice\PersisterInterface');
-        
-        $loader = new Loader($aliceLoaderProphecy->reveal(), ['dummyProcessor'], false);
+
+        $loader = new Loader($aliceLoaderProphecy->reveal(), ['dummyProcessor'], false, 5);
         $objects = $loader->load($persisterProphecy->reveal(), []);
 
         $this->assertEquals([], $objects);
@@ -77,7 +77,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy->setPersister($persisterProphecy->reveal())->shouldBeCalled();
         $fixturesLoaderProphecy->setPersister($oldPersister)->shouldBeCalled();
 
-        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false);
+        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false, 5);
         $objects = $loader->load($persisterProphecy->reveal(), ['random/file']);
 
         $this->assertEquals([$object], $objects);
@@ -107,7 +107,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy->setPersister($persisterProphecy->reveal())->shouldBeCalled();
         $fixturesLoaderProphecy->setPersister($oldPersister)->shouldBeCalled();
 
-        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false);
+        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false, 5);
         $objects = $loader->load(
             $persisterProphecy->reveal(),
             [
@@ -142,7 +142,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy->setPersister($persisterProphecy->reveal())->shouldBeCalled();
         $fixturesLoaderProphecy->setPersister($oldPersister)->shouldBeCalled();
 
-        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], true);
+        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], true, 5);
         $objects = $loader->load(
             $persisterProphecy->reveal(),
             [
@@ -177,7 +177,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $processorProphecy->preProcess($object)->shouldBeCalled();
         $processorProphecy->postProcess($object)->shouldBeCalled();
 
-        $loader = new Loader($fixturesLoaderProphecy->reveal(), [$processorProphecy->reveal()], false);
+        $loader = new Loader($fixturesLoaderProphecy->reveal(), [$processorProphecy->reveal()], false, 5);
         $objects = $loader->load($persisterProphecy->reveal(), ['random/file']);
 
         $this->assertEquals([$object], $objects);
@@ -193,7 +193,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\LoaderInterface');
         $fixturesLoaderProphecy->load('random/file', [])->willReturn([$object]);
 
-        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false);
+        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false, 5);
         $objects = $loader->load($persisterProphecy->reveal(), ['random/file']);
 
         $this->assertEquals([$object], $objects);
@@ -211,7 +211,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy->load('random/file', [])->willThrow(new \UnexpectedValueException());
         $fixturesLoaderProphecy->load('random/file', [])->shouldBeCalledTimes(6);
 
-        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false);
+        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false, 5);
         $loader->load($persisterProphecy->reveal(), ['random/file']);
     }
 
@@ -227,8 +227,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy->load('random/file', [])->willThrow(new \UnexpectedValueException());
         $fixturesLoaderProphecy->load('random/file', [])->shouldBeCalledTimes(11);
 
-        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false);
-        $loader->setLoadingLimit(10);
+        $loader = new Loader($fixturesLoaderProphecy->reveal(), [], false, 10);
         $loader->load($persisterProphecy->reveal(), ['random/file']);
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -22,14 +22,15 @@ use Symfony\Component\Config\Definition\Processor;
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {
     private static $defaultConfig = [
-        'db_drivers' => [
+        'db_drivers'    => [
             'orm'     => null,
             'mongodb' => null,
             'phpcr'   => null,
         ],
-        'locale'       => 'en_US',
-        'seed'         => 1,
-        'persist_once' => false,
+        'locale'        => 'en_US',
+        'seed'          => 1,
+        'persist_once'  => false,
+        'loading_limit' => 5,
     ];
 
     /**

--- a/tests/DependencyInjection/HautelookAliceExtensionTest.php
+++ b/tests/DependencyInjection/HautelookAliceExtensionTest.php
@@ -404,6 +404,7 @@ class HautelookAliceExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $containerBuilderProphecy = $this->prophesize('Symfony\Component\DependencyInjection\ContainerBuilder');
 
+        $containerBuilderProphecy->setParameter('hautelook_alice.loading_limit', 5)->shouldBeCalled();
         $containerBuilderProphecy->setParameter('hautelook_alice.locale', 'en_US')->shouldBeCalled();
         $containerBuilderProphecy->setParameter('hautelook_alice.seed', 1)->shouldBeCalled();
         $containerBuilderProphecy->setParameter('hautelook_alice.persist_once', false)->shouldBeCalled();

--- a/tests/Doctrine/Generator/GeneratorTest.php
+++ b/tests/Doctrine/Generator/GeneratorTest.php
@@ -29,7 +29,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $fixturesFinderProphecy = $this->prophesize('Hautelook\AliceBundle\Doctrine\Finder\FixturesFinder');
 
-        new LoaderGenerator($fixturesFinderProphecy->reveal());
+        new LoaderGenerator($fixturesFinderProphecy->reveal(), 5);
     }
 
     /**
@@ -56,6 +56,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy->load('fixtureFile', [])->willReturn(['fixtureObject']);
 
         $loaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\LoaderInterface');
+        $loaderProphecy->getLoadingLimit()->willReturn(5);
         $loaderProphecy->getProcessors()->willReturn([$processorProphecy->reveal()]);
         $loaderProphecy->getPersistOnce()->willReturn(true);
 


### PR DESCRIPTION
I'm trying to add loading limit on configuration to set a default, but I'm facing on a problem: Your service is never used.

Instead, a instance of loader is created on `LoaderGenerator`: https://github.com/hautelook/AliceBundle/blob/e739300431db9fc9706006bde7b5e8d321c11a7d/src/Doctrine/Generator/LoaderGenerator.php#L51-L55

Two questions:

* Why? :-)
* How to handle this parameter?