### PR TITLE
Fix Symfony 2.3 command input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ matrix:
     - env: SYMFONY_VERSION=2.8.*@dev
     - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
     # TODO: Remove those two line when test will be fixed.
-    - env: SYMFONY_VERSION=2.3.*
     - env: COMPOSER_FLAGS="--prefer-lowest"
 
 services:

--- a/tests/Doctrine/Command/DoctrineDataFixturesCommandsTest.php
+++ b/tests/Doctrine/Command/DoctrineDataFixturesCommandsTest.php
@@ -37,7 +37,7 @@ class DoctrineDataFixturesCommandsTest extends CommandTestCase
         $command = $this->application->find('doctrine:fixtures:load');
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute([], ['interactive' => false]);
+        $commandTester->execute(['command' => 'doctrine:fixtures:load'], ['interactive' => false]);
 
         $expected = <<<EOF
               > purging database
@@ -61,7 +61,7 @@ EOF;
         $command = $this->application->find('doctrine:mongodb:fixtures:load');
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute([], ['interactive' => false]);
+        $commandTester->execute(['command' => 'doctrine:mongodb:fixtures:load'], ['interactive' => false]);
 
         $expected = <<<EOF
               > purging database
@@ -77,7 +77,7 @@ EOF;
         $command = $this->application->find('doctrine:mongodb:fixtures:load');
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute([], ['interactive' => false]);
+        $commandTester->execute(['command' => 'doctrine:mongodb:fixtures:load'], ['interactive' => false]);
 
         $expected = <<<EOF
               > purging database

--- a/tests/Doctrine/Command/DoctrineODMFixturesTest.php
+++ b/tests/Doctrine/Command/DoctrineODMFixturesTest.php
@@ -41,7 +41,7 @@ class DoctrineODMFixturesTest extends CommandTestCase
         $command = $this->application->find('hautelook_alice:doctrine:mongodb:fixtures:load');
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute([], ['interactive' => false]);
+        $commandTester->execute(['command' => 'hautelook_alice:doctrine:mongodb:fixtures:load'], ['interactive' => false]);
 
         $this->verifyProducts();
     }
@@ -57,7 +57,7 @@ class DoctrineODMFixturesTest extends CommandTestCase
         $command = $this->application->find('hautelook_alice:doctrine:mongodb:fixtures:load');
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute($inputs, ['interactive' => false]);
+        $commandTester->execute(array_merge(['command' => 'hautelook_alice:doctrine:mongodb:fixtures:load'], $inputs), ['interactive' => false]);
 
         $this->assertFixturesDisplayEquals($expected, $commandTester->getDisplay());
     }

--- a/tests/Doctrine/Command/DoctrineORMFixturesTest.php
+++ b/tests/Doctrine/Command/DoctrineORMFixturesTest.php
@@ -44,7 +44,7 @@ class DoctrineORMFixturesTest extends CommandTestCase
         $command = $this->application->find('hautelook_alice:doctrine:fixtures:load');
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute([], ['interactive' => false]);
+        $commandTester->execute(['command' => 'hautelook_alice:doctrine:fixtures:load'], ['interactive' => false]);
 
         $this->verifyProducts();
         $this->verifyBrands();
@@ -61,7 +61,7 @@ class DoctrineORMFixturesTest extends CommandTestCase
         $command = $this->application->find('hautelook_alice:doctrine:fixtures:load');
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute($inputs, ['interactive' => false]);
+        $commandTester->execute(array_merge(['command' => 'hautelook_alice:doctrine:fixtures:load'], $inputs), ['interactive' => false]);
 
         $this->assertFixturesDisplayEquals($expected, $commandTester->getDisplay());
     }


### PR DESCRIPTION
'command' option is needed on 2.3

This fix all SF 2.3 tests.