### PR TITLE
Fix Faker generator declarations

### DIFF
--- a/src/Resources/doc/faker-providers.md
+++ b/src/Resources/doc/faker-providers.md
@@ -54,6 +54,7 @@ instance. AliceBundle provides a faker generator `hautelook_alice.faker` configu
 services:
     hautelook_alice.bare_faker:
         class: Faker\Generator
+        factory: [ Faker\Factory, create ]
         lazy: true
         arguments:
             - %hautelook_alice.locale%


### PR DESCRIPTION
Faker generators should be generated by [`Faker\Factory::create()`](https://github.com/fzaninotto/Faker/blob/master/src/Faker/Factory.php#L17).

cc @Soullivaneuh 