### PR TITLE
Prevent php-cs-fixer to apply psr0 fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,9 @@ EOF;
 
 HeaderCommentFixer::setHeader($header);
 
-return ConfigBridge::create()
+$config = ConfigBridge::create();
+
+return $config
     ->setUsingCache(true)
+    ->fixers(array_merge($config->getFixers(), ['-psr0']))
 ;


### PR DESCRIPTION
Actually, if you run the fixer, it will change all class namespaces on tests folder.