### PR TITLE
Use branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,5 +55,10 @@
     },
     "autoload-dev": {
         "psr-4": { "Hautelook\\AliceBundle\\Tests\\": "tests" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Will be useful if someone want a 1.x version but with latest commits not released yet.

E.g.: `^1.0.1` or `~1.0,>1.0.0`.