### PR TITLE
Use Symfony stable releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ matrix:
     - php: 7.0
     - php: nightly
     - php: hhvm
-    - env: SYMFONY_VERSION=2.8.*@dev
-    - env: SYMFONY_VERSION="3.0.*@dev"
+    - env: SYMFONY_VERSION=2.8.*
+    - env: SYMFONY_VERSION=3.0.*
     # TODO: Remove those two line when test will be fixed.
     - env: COMPOSER_FLAGS="--prefer-lowest"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.7.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.*@dev
+      env: SYMFONY_VERSION=2.8.*
     - php: 5.6
-      env: SYMFONY_VERSION="3.0.*@dev"
+      env: SYMFONY_VERSION=3.0.*
   allow_failures:
     - php: 7.0
     - php: nightly


### PR DESCRIPTION
Use Symfony 2.8 et 3.0 stable releases instead of the dev one.