### PR TITLE
Fix deprecated Not quoting a scalar starting with `@` on fixtures

### DIFF
--- a/tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
+++ b/tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
@@ -6,7 +6,7 @@ Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity\Product:
         name: Product <current()>
         price: 10.0
         description: Awesome <identity(@self->name)>
-        brand: @brand*
+        brand: '@brand*'
 
 Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity\Brand:
     brand{1..10}:

--- a/tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
+++ b/tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
@@ -3,4 +3,4 @@ Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity\Product:
         name: Product <current()>
         price: 10.0
         description: Awesome <identity(@self->name)>
-        brand: @brand*
+        brand: '@brand*'


### PR DESCRIPTION
Replace #171.