### PR TITLE
Enable shard option on load fixtures command

### DIFF
--- a/tests/Doctrine/Command/DoctrineORMFixturesTest.php
+++ b/tests/Doctrine/Command/DoctrineORMFixturesTest.php
@@ -34,6 +34,13 @@ class DoctrineORMFixturesTest extends CommandTestCase
         );
 
         $this->entityManager = $this->application->getKernel()->getContainer()->get('doctrine')->getManager();
+
+        // Create shard database
+        $connection = $this->entityManager->getConnection();
+        $connection->connect(1);
+        $this->runConsole('doctrine:schema:drop', ['--force' => true]);
+        $this->runConsole('doctrine:schema:create');
+        $connection->connect(0);
     }
 
     /**
@@ -282,6 +289,25 @@ EOF
       - /home/travis/build/theofidry/AliceBundle/tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
       - /home/travis/build/theofidry/AliceBundle/tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
       - /home/travis/build/theofidry/AliceBundle/tests/SymfonyApp/TestBundle/DataFixtures/ORM/Provider/testFormatter.yml
+  > purging database
+  > fixtures loaded
+
+EOF
+        ];
+
+        $data[] = [
+            [
+                '--env'     => 'Shard',
+                '--shard'   => 1,
+                '--bundle'  => [
+                    'TestBundle',
+                ],
+            ],
+            <<<'EOF'
+              > fixtures found:
+      - /home/travis/build/theofidry/AliceBundle/tests/SymfonyApp/TestBundle/DataFixtures/ORM/brand.yml
+      - /home/travis/build/theofidry/AliceBundle/tests/SymfonyApp/TestBundle/DataFixtures/ORM/product.yml
+      - /home/travis/build/theofidry/AliceBundle/tests/SymfonyApp/TestBundle/DataFixtures/ORM/Shard/shard.yml
   > purging database
   > fixtures loaded
 

--- a/tests/SymfonyApp/TestBundle/Entity/Shard.php
+++ b/tests/SymfonyApp/TestBundle/Entity/Shard.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hautelook\AliceBundle\Tests\SymfonyApp\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Shard
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @return int|null
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/SymfonyApp/config/config.yml
+++ b/tests/SymfonyApp/config/config.yml
@@ -20,9 +20,15 @@ doctrine:
                 connection: default
                 auto_mapping: true
     dbal:
-        driver: pdo_sqlite
-        path: %kernel.cache_dir%/db.sqlite
-        charset: UTF8
+        connections:
+            default:
+                driver: pdo_sqlite
+                path: %kernel.cache_dir%/db.sqlite
+                charset: UTF8
+                wrapper_class: Doctrine\DBAL\Sharding\PoolingShardConnection
+                shard_choser: Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser
+                shards:
+                    - { id: 1, path: %kernel.cache_dir%/db_shard.sqlite }
 
 doctrine_mongodb:
     connections:


### PR DESCRIPTION
Allow to specify `shard` option on `hautelook_alice:doctrine:fixtures:load` command:
```
php app/console hautelook_alice:doctrine:fixtures:load --env=foo --manager=foo --shard=1
```

If related connection is instance of `PoolingShardConnection`, it will switch to correct shard database identified by requested id.