### PR TITLE
Update ORM unit tests supporting MySQL & SQLite DB platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
 
 services:
   - mongodb
+  - mysql
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,19 @@
             "homepage": "https://github.com/theofidry"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/lafourchette/DoctrineBundle"
+        }
+    ],
     "require": {
         "php": ">=5.4.0",
         "nelmio/alice": "~2.1",
         "symfony/finder": "^2.7|~3.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "~1.2",
+        "doctrine/doctrine-bundle": "dev-sharding-erb as 1.2.x-dev",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "doctrine/mongodb-odm": "^1.0",
         "doctrine/mongodb-odm-bundle": "^3.0",
@@ -34,8 +40,7 @@
         "symfony/yaml": "~2.3|~3.0",
         "symfony/validator": "~2.3|~3.0",
         "sllh/php-cs-fixer-styleci-bridge": "~1.0",
-        "symfony/phpunit-bridge": "^2.7.4|~3.0",
-        "phpunit/phpunit": "~4.8"
+        "symfony/phpunit-bridge": "^2.7.4|~3.0"
     },
     "suggest": {
         "theofidry/alice-bundle-extension": "Behat extension for HautelookAliceBundle",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "symfony/yaml": "~2.3|~3.0",
         "symfony/validator": "~2.3|~3.0",
         "sllh/php-cs-fixer-styleci-bridge": "~1.0",
-        "symfony/phpunit-bridge": "^2.7.4|~3.0"
+        "symfony/phpunit-bridge": "^2.7.4|~3.0",
+        "phpunit/phpunit": "~4.8"
     },
     "suggest": {
         "theofidry/alice-bundle-extension": "Behat extension for HautelookAliceBundle",

--- a/tests/SymfonyApp/config/config.yml
+++ b/tests/SymfonyApp/config/config.yml
@@ -18,7 +18,20 @@ doctrine:
         entity_managers:
             default:
                 connection: default
-                auto_mapping: true
+                mappings:
+                    TestBundle: ~
+                    TestABundle: ~
+                    TestBBundle: ~
+                    TestCBundle: ~
+                    TestDBundle: ~
+            mysql:
+                connection: mysql
+                mappings:
+                    TestBundle: ~
+                    TestABundle: ~
+                    TestBBundle: ~
+                    TestCBundle: ~
+                    TestDBundle: ~
     dbal:
         connections:
             default:
@@ -29,6 +42,25 @@ doctrine:
                 shard_choser: Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser
                 shards:
                     - { id: 1, path: %kernel.cache_dir%/db_shard.sqlite }
+            mysql:
+                driver: pdo_mysql
+                host: localhost
+                port: 3306
+                dbname: alice
+                user: root
+                password: null
+                charset: utf8
+                server_version: 5.6
+                wrapper_class: Doctrine\DBAL\Sharding\PoolingShardConnection
+                shard_choser: Doctrine\DBAL\Sharding\ShardChoser\MultiTenantShardChoser
+                shards:
+                    - id: 1
+                      host: localhost
+                      port: 3306
+                      dbname: alice_shard_1
+                      user: root
+                      password: null
+                      charset: utf8
 
 doctrine_mongodb:
     connections:


### PR DESCRIPTION
From https://github.com/hautelook/AliceBundle/pull/197
DB platforms supported: MySQL, SQLite, MongoDB
- [x] Use [DoctrineBundle fork from LaFourchette](https://github.com/lafourchette/DoctrineBundle/tree/sharding-erb) in `require-dev`