### PR TITLE
[Loader] Fix references

### DIFF
--- a/src/Alice/DataFixtures/Loader.php
+++ b/src/Alice/DataFixtures/Loader.php
@@ -199,6 +199,7 @@ class Loader implements LoaderInterface
                 }
 
                 $objects = array_merge($objects, $dataSet);
+                $references = array_merge($references, $dataSet);
             } catch (\UnexpectedValueException $exception) {
                 $this->registerErrorMessage($fixtureFilePath, $exception->getMessage());
             }

--- a/tests/Alice/DataFixtures/LoaderTest.php
+++ b/tests/Alice/DataFixtures/LoaderTest.php
@@ -104,7 +104,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\Loader');
         $fixturesLoaderProphecy->getPersister()->willReturn($oldPersister);
         $fixturesLoaderProphecy->load('random/file1', [])->willReturn([$objects[0]]);
-        $fixturesLoaderProphecy->load('random/file2', [])->willReturn([$objects[0]]);
+        $fixturesLoaderProphecy->load('random/file2', [$objects[0]])->willReturn([$objects[0]]);
         $fixturesLoaderProphecy->setPersister($persisterProphecy->reveal())->shouldBeCalled();
         $fixturesLoaderProphecy->setPersister($oldPersister)->shouldBeCalled();
 
@@ -139,7 +139,7 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $fixturesLoaderProphecy = $this->prophesize('Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\Loader');
         $fixturesLoaderProphecy->getPersister()->willReturn($oldPersister);
         $fixturesLoaderProphecy->load('random/file1', [])->willReturn([$objects[0]]);
-        $fixturesLoaderProphecy->load('random/file2', [])->willReturn([$objects[0]]);
+        $fixturesLoaderProphecy->load('random/file2', [$objects[0]])->willReturn([$objects[0]]);
         $fixturesLoaderProphecy->setPersister($persisterProphecy->reveal())->shouldBeCalled();
         $fixturesLoaderProphecy->setPersister($oldPersister)->shouldBeCalled();
 


### PR DESCRIPTION
Hey!

This PR is the same as #206 but with updating the tests accordingly. In #206, @adrienbrault explains he tries to reduce the max limit reached as well as improving performance by merging the references directly in the `tryToLoadFiles` method. 

Indeed, it improves performance dramatically especially if you play with a deep object graph as well as lot of objects and lot of fixtures files. Additionally, if you create a specific data loader in order to define a precise/deterministic order for the fixtures, in theory, everything should be handled without throwing any `UnexpectedValueException` in the middle of the iteration. But since the references are not updated in the iteration, even if you put your fixtures in the right order, the `UnexpectedValueException` is thrown.

Additionally (I'm not sure you're aware of this part and this is what @geoffrey-brier (a coworker) tries to explain [here](https://github.com/hautelook/AliceBundle/pull/206#issuecomment-224359340)), if an `UnexpectedValueException` is thrown, then your fixtures can be broken because this exception can be detected in the middle of a fixture file processing, meaning everything define in the fixture file (before the unexpected value) has been handled (creating the object and injecting it in your setter, etc) but the fixture file are not tagged as processed. Then on the next retry, the same objects are re-created and re-injected into an other (resulting a duplication of objects in some relations and some objects have not been persisted in the doctrine object manager because they have not been merged into the returned objects)...

By merging the references, it fixes our issue (because we put our fixtures in a deterministic order) but it is still here if you don't do that...

WDYT?