### PR TITLE
Adding short alias for command: fixtures:load

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ AppBundle\Entity\RelatedDummy:
         name: <name()>
 ```
 
-Then simply load your fixtures with the doctrine command `php app/console hautelook_alice:doctrine:fixtures:load` (or `php app/console h:d:f:l`).
+Then simply load your fixtures with the doctrine command `php app/console fixtures:load`.
 
-If you want to load the fixtures of a bundle only, do `php app/console h:d:f:l -b MyFirstBundle -b MySecondBundle`.
+If you want to load the fixtures of a bundle only, do `php app/console fixtures:load -b MyFirstBundle -b MySecondBundle`.
 
 [See more](#documentation).<br />
 Next chapter: [Advanced usage](src/Resources/doc/advanced-usage.md)

--- a/src/Doctrine/Command/LoadDataFixturesCommand.php
+++ b/src/Doctrine/Command/LoadDataFixturesCommand.php
@@ -109,6 +109,7 @@ class LoadDataFixturesCommand extends Command
     protected function configure()
     {
         $this
+            ->setAliases(['fixtures:load'])
             ->setDescription('Load data fixtures to your database.')
             ->addOption(
                 'bundle',


### PR DESCRIPTION
Hi guys!

Silly as it sounds, one of the things I've never liked about this bundle is the *very* long command name - I can never remember it (and I also can't remember the short, `h:d:f:l` either).

I would just love to have this shortcut alias, instead. I know this could conflict with existing commands by this name, but will that really happen? If so, someone could send a PR in the future to make this an alias that could be turned off (but that may never happen).

If this were accepted, I'd probably update the README to use this short command.

Thanks for the consideration!