### PR TITLE
Allow loading fixtures from PHP files

### DIFF
--- a/src/Finder/FixturesFinder.php
+++ b/src/Finder/FixturesFinder.php
@@ -118,7 +118,7 @@ class FixturesFinder implements FixturesFinderInterface
     {
         $fixtures = [];
 
-        $finder = SymfonyFinder::create()->in($path)->depth(0)->files()->name('*.yml');
+        $finder = SymfonyFinder::create()->in($path)->depth(0)->files()->name('*.yml')->name('*.php');
         foreach ($finder as $file) {
             /* @var SplFileInfo $file */
             $fixtures[$file->getRealPath()] = true;


### PR DESCRIPTION
nelmio/alice supports [loading fixtures from plain PHP](https://github.com/nelmio/alice/blob/master/doc/complete-reference.md#php) as well which is quite useful when yaml is not enough.