### PR TITLE
Support fixtures outside bundles AKA Symfony Flex support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor/
 composer.lock
 coverage.xml
+fixtures/Functional/cache/
 phpunit.xml
 .php_cs.cache
 .phar/

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Configure the bundle to your needs (example with default values):
 # app/config/config_dev.yml
 
 hautelook_alice:
-    fixtures_path: 'Resources/fixtures/orm' # Path to which to look for fixtures relative to the bundle path.
+    fixtures_path: 'Resources/fixtures/orm' # Path to which to look for fixtures relative to the project directory or the bundle path.
 ```
 
 

--- a/resources/config/locator.xml
+++ b/resources/config/locator.xml
@@ -7,6 +7,7 @@
         <service id="hautelook_alice.locator.env_directory"
                  class="Hautelook\AliceBundle\Locator\EnvDirectoryLocator">
             <argument type="string">%hautelook_alice.fixtures_path%</argument>
+            <argument type="string" on-invalid="ignore">%kernel.project_dir%</argument>
         </service>
 
         <service id="hautelook_alice.locator.environmentless"

--- a/tests/Locator/EnvDirectoryLocatorTest.php
+++ b/tests/Locator/EnvDirectoryLocatorTest.php
@@ -168,6 +168,13 @@ class EnvDirectoryLocatorTest extends \PHPUnit_Framework_TestCase
                 $prefixB.'file3.php',
             ]
         ];
+    }
 
+    public function testGetFilesFromProjectDir()
+    {
+        $basePath = realpath(__DIR__.'/../..');
+
+        $locator = new EnvDirectoryLocator('fixtures/fixture_files', $basePath);
+        $this->assertSame([$basePath.'/fixtures/fixture_files/city.yml'], $locator->locateFiles([], ''));
     }
 }


### PR DESCRIPTION
Fix #296.

To use it with Flex:

```yml
hautelook_alice:
    fixtures_path: 'fixtures'
```

Then put your fixture files in a `fixtures/` directory at the root of the project.