### PR TITLE
Ignore purging read only tables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "hautelook/alice-bundle",
-    "description": "Symfony2 Bundle to manage fixtures with Alice and Faker.",
+    "name": "zecho/alice-bundle",
+    "description": "Symfony bundle to manage fixtures with Alice and Faker.",
     "keywords": ["Symfony", "Fixture", "ORM", "Alice", "Faker"],
     "type": "symfony-bundle",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "zecho/alice-bundle",
-    "description": "Symfony bundle to manage fixtures with Alice and Faker.",
+    "name": "hautelook/alice-bundle",
+    "description": "Symfony2 Bundle to manage fixtures with Alice and Faker.",
     "keywords": ["Symfony", "Fixture", "ORM", "Alice", "Faker"],
     "type": "symfony-bundle",
     "license": "MIT",


### PR DESCRIPTION
This is a hotfix to allow ignoring entities marked as read only like views etc. It also use properly the tables schema. Tested with PostgreSQL.