### PR TITLE
removing hard dependency for doctrine bundle

### DIFF
--- a/src/DependencyInjection/HautelookAliceExtension.php
+++ b/src/DependencyInjection/HautelookAliceExtension.php
@@ -45,14 +45,6 @@ final class HautelookAliceExtension extends Extension
                 )
             );
         }
-        if (false === array_key_exists('Doctrine\Bundle\DoctrineBundle\DoctrineBundle', $bundles)) {
-            throw new LogicException(
-                sprintf(
-                    'Cannot register "%s" without "Doctrine\Bundle\DoctrineBundle\DoctrineBundle".',
-                    HautelookAliceBundle::class
-                )
-            );
-        }
 
         $this->loadConfig($configs, $container);
         $this->loadServices($container);


### PR DESCRIPTION
As mentioned here https://github.com/hautelook/AliceBundle/issues/380#issuecomment-357746965 and in the Readme "...As FidryAliceDataFixtures is compatible with different databases/ORM, one cannot be installed by default..." the doctrine bundle shouldn't be a hard dependency when not needed.

would solve the problems for the contrib-recepie here: https://github.com/symfony/recipes-contrib/pull/252