### PR TITLE
adds check for service tag

### DIFF
--- a/src/DependencyInjection/HautelookAliceExtension.php
+++ b/src/DependencyInjection/HautelookAliceExtension.php
@@ -57,6 +57,7 @@ final class HautelookAliceExtension extends Extension
         $this->loadConfig($configs, $container);
         $this->loadServices($container);
 
+        // TODO: remove it in the future as we bump the minimal requirement of nelmio/alice
         // Register autoconfiguration rules for Symfony DI 3.3+
         if (method_exists($container, 'registerForAutoconfiguration')) {
             if ( 0 === count($container->findTaggedServiceIds('nelmio_alice.faker.provider')) ) {

--- a/src/DependencyInjection/HautelookAliceExtension.php
+++ b/src/DependencyInjection/HautelookAliceExtension.php
@@ -59,8 +59,10 @@ final class HautelookAliceExtension extends Extension
 
         // Register autoconfiguration rules for Symfony DI 3.3+
         if (method_exists($container, 'registerForAutoconfiguration')) {
-            $container->registerForAutoconfiguration(Base::class)
-                ->addTag('nelmio_alice.faker.provider');
+            if ( 0 === count($container->findTaggedServiceIds('nelmio_alice.faker.provider')) ) {
+                $container->registerForAutoconfiguration(Base::class)
+                    ->addTag('nelmio_alice.faker.provider');
+            }
         }
     }
 


### PR DESCRIPTION
currently alice and aliceBundle both try to autoRegister classes which are extending BaseFakerProvider.

preventing this happening until alice bundle bumps version information about require nelmio/alice