### PR TITLE
Fix the behavior when DoctrineBundle isn't installed

### DIFF
--- a/src/DependencyInjection/HautelookAliceExtension.php
+++ b/src/DependencyInjection/HautelookAliceExtension.php
@@ -18,7 +18,6 @@ use Hautelook\AliceBundle\HautelookAliceBundle;
 use LogicException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -50,17 +49,16 @@ final class HautelookAliceExtension extends Extension
             );
         }
 
-        $this->loadConfig($configs, $container);
-        $this->loadServices($container);
-
         if (false === array_key_exists(DoctrineBundle::class, $bundles)) {
-            $container->removeDefinition('hautelook_alice.console.command.doctrine.doctrine_orm_load_data_fixtures_command');
-
-            $definition = new Definition(DoctrineOrmMissingBundleInformationCommand::class);
+            $definition = $container->register(DoctrineOrmMissingBundleInformationCommand::class, DoctrineOrmMissingBundleInformationCommand::class);
             $definition->addTag('console.command');
             $definition->setPublic(true);
-            $container->setDefinition('hautelook_alice.console.command.doctrine.doctrine_orm_bundle_missing_command', $definition);
+
+            return;
         }
+
+        $this->loadConfig($configs, $container);
+        $this->loadServices($container);
     }
 
     /**

--- a/tests/DependencyInjection/HautelookAliceBundleTest.php
+++ b/tests/DependencyInjection/HautelookAliceBundleTest.php
@@ -12,6 +12,7 @@
 namespace Hautelook\AliceBundle\DependencyInjection;
 
 use Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle;
+use Hautelook\AliceBundle\Console\Command\Doctrine\DoctrineOrmMissingBundleInformationCommand;
 use Hautelook\AliceBundle\Functional\AppKernel;
 use Hautelook\AliceBundle\Functional\ConfigurableKernel;
 use Hautelook\AliceBundle\Functional\WithoutDoctrineKernel;
@@ -51,10 +52,6 @@ class HautelookAliceBundleTest extends TestCase
         $this->kernel->boot();
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessageRegExp  /non-existent service/
-     */
     public function testWillReplaceFixtureLoadCommandWithErrorInformationCommandIfDoctrineBundleIsNotRegistered()
     {
         $this->kernel = new WithoutDoctrineKernel('ConfigurableKernel1', true);
@@ -62,13 +59,10 @@ class HautelookAliceBundleTest extends TestCase
         $this->kernel->addBundle(new NelmioAliceBundle());
         $this->kernel->boot();
 
-        // Commands
         $this->assertInstanceOf(
-            \Hautelook\AliceBundle\Console\Command\Doctrine\DoctrineOrmMissingBundleInformationCommand::class,
-            $this->kernel->getContainer()->get('hautelook_alice.console.command.doctrine.doctrine_orm_bundle_missing_command')
+            DoctrineOrmMissingBundleInformationCommand::class,
+            $this->kernel->getContainer()->get(DoctrineOrmMissingBundleInformationCommand::class)
         );
-
-        $this->kernel->getContainer()->get('hautelook_alice.console.command.doctrine.doctrine_orm_load_data_fixtures_command');
     }
 
     public function testServiceRegistration()


### PR DESCRIPTION
/!\\: #428 is probably a better solution

Currently when this bundle is installed but DoctrineORM isn't the whole app is broken, see https://travis-ci.org/symfony/recipes-contrib/jobs/430445745

This PR fixes this behavior.