### PR TITLE
Make the Phpunit trait compatible with WebTestCase

### DIFF
--- a/src/PhpUnit/RefreshDatabaseTrait.php
+++ b/src/PhpUnit/RefreshDatabaseTrait.php
@@ -37,6 +37,7 @@ trait RefreshDatabaseTrait
 
         $container = static::$container ?? static::$kernel->getContainer();
         $container->get('doctrine')->getConnection(static::$connection)->beginTransaction();
+
         return $kernel;
     }
 

--- a/src/PhpUnit/RefreshDatabaseTrait.php
+++ b/src/PhpUnit/RefreshDatabaseTrait.php
@@ -28,7 +28,7 @@ trait RefreshDatabaseTrait
     protected static function bootKernel(array $options = [])
     {
         static::ensureKernelTestCase();
-        parent::bootKernel($options);
+        $kernel = parent::bootKernel($options);
 
         if (!static::$dbPopulated) {
             static::populateDatabase();
@@ -37,6 +37,7 @@ trait RefreshDatabaseTrait
 
         $container = static::$container ?? static::$kernel->getContainer();
         $container->get('doctrine')->getConnection(static::$connection)->beginTransaction();
+        return $kernel;
     }
 
     protected static function ensureKernelShutdown()

--- a/src/PhpUnit/ReloadDatabaseTrait.php
+++ b/src/PhpUnit/ReloadDatabaseTrait.php
@@ -25,7 +25,8 @@ trait ReloadDatabaseTrait
     protected static function bootKernel(array $options = [])
     {
         static::ensureKernelTestCase();
-        parent::bootKernel($options);
+        $kernel = parent::bootKernel($options);
         static::populateDatabase();
+        return $kernel;
     }
 }

--- a/src/PhpUnit/ReloadDatabaseTrait.php
+++ b/src/PhpUnit/ReloadDatabaseTrait.php
@@ -27,6 +27,7 @@ trait ReloadDatabaseTrait
         static::ensureKernelTestCase();
         $kernel = parent::bootKernel($options);
         static::populateDatabase();
+
         return $kernel;
     }
 }


### PR DESCRIPTION
Symfony `WebTestCase` [uses the return value of `bootKernel`](https://github.com/symfony/framework-bundle/blob/master/Test/WebTestCase.php#L33) as a reference to the Kernel.

Therefore it must be returned by the traits :)