### PR TITLE
Fix root node deprecation in symfony/config > 4.1

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,8 +27,14 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('hautelook_alice');
+        $treeBuilder = new TreeBuilder('hautelook_alice');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC for symfony/config < 4.2
+            $rootNode = $treeBuilder->root('hautelook_alice');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fixes the deprecation warnings about tree builders without root nodes being deprecated since 4.2. This fix is BC with 4.1 and older and is similar to the [fix applied to doctrine/DoctrineBundle](https://github.com/doctrine/DoctrineBundle/pull/853/files).