### PR TITLE
Do not rollback if there are no active transactions

### DIFF
--- a/src/PhpUnit/RefreshDatabaseTrait.php
+++ b/src/PhpUnit/RefreshDatabaseTrait.php
@@ -49,7 +49,10 @@ trait RefreshDatabaseTrait
         }
 
         if (null !== $container) {
-            $container->get('doctrine')->getConnection(static::$connection)->rollBack();
+            $connection = $container->get('doctrine')->getConnection(static::$connection);
+            if ($connection->isTransactionActive()) {
+                $connection->rollback();
+            }
         }
 
         parent::ensureKernelShutdown();


### PR DESCRIPTION
In the RefreshDatabaseTrait.