### PR TITLE
Fix overriding custom path fixtures root dir

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ namespace Hautelook\AliceBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @private
@@ -36,6 +37,16 @@ final class Configuration implements ConfigurationInterface
             $rootNode = $treeBuilder->root('hautelook_alice');
         }
 
+        $defaultRootDirsValue = [
+            '%kernel.root_dir%',
+            '%kernel.project_dir%',
+        ];
+        if (Kernel::VERSION_ID >= 50000) {
+            $defaultRootDirsValue = [
+                '%kernel.project_dir%',
+            ];
+        }
+
         $rootNode
             ->children()
                 ->arrayNode('fixtures_path')
@@ -46,10 +57,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('root_dirs')
                     ->info('List of root directories into which to look for the fixtures.')
-                    ->defaultValue([
-                        '%kernel.root_dir%',
-                        '%kernel.project_dir%',
-                    ])
+                    ->defaultValue($defaultRootDirsValue)
                     ->scalarPrototype()
                 ->end()
             ->end()

--- a/src/DependencyInjection/HautelookAliceExtension.php
+++ b/src/DependencyInjection/HautelookAliceExtension.php
@@ -20,7 +20,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @private
@@ -69,10 +68,6 @@ final class HautelookAliceExtension extends Extension
     {
         $configuration = new Configuration();
         $processedConfiguration = $this->processConfiguration($configuration, $configs);
-
-        if (Kernel::VERSION_ID >= 40000) {
-            $processedConfiguration['root_dirs'] = ['%kernel.project_dir%'];
-        }
 
         foreach ($processedConfiguration as $key => $value) {
             $container->setParameter(

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,7 @@ namespace Hautelook\AliceBundle\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @covers \Hautelook\AliceBundle\DependencyInjection\Configuration
@@ -31,6 +32,15 @@ class ConfigurationTest extends TestCase
                 '%kernel.project_dir%',
             ],
         ];
+
+        if (Kernel::VERSION_ID >= 50000) {
+            $expected = [
+                'fixtures_path' => ['Resources/fixtures'],
+                'root_dirs' => [
+                    '%kernel.project_dir%',
+                ],
+            ];
+        }
 
         $actual = $processor->processConfiguration($configuration, []);
 


### PR DESCRIPTION
Symfony 5.0 Support - fix issue custom root_dirs fixtures caused by PR #487 