### PR TITLE
Updated factory documentation

### DIFF
--- a/doc/advanced-usage.md
+++ b/doc/advanced-usage.md
@@ -105,7 +105,7 @@ factories](https://github.com/nelmio/alice/blob/master/doc/complete-reference.md
 
 AppBundle\Entity\Dummy:
     dummy_0:
-        __construct: { '@dummy_factory::create': ['<username()>'] }
+        __factory: { '@dummy_factory::create': ['<username()>'] }
 ```
 
 


### PR DESCRIPTION
Using __constructor for a factory is deprecated since 3.0.0 and removed in 4.0.0:

https://github.com/nelmio/alice/blob/master/doc/complete-reference.md#using-a-factory--a-named-constructor