### PR TITLE
Remove `final` keyword from DoctrineOrmLoader

### DIFF
--- a/src/Loader/DoctrineOrmLoader.php
+++ b/src/Loader/DoctrineOrmLoader.php
@@ -29,7 +29,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
-final class DoctrineOrmLoader implements AliceBundleLoaderInterface, LoggerAwareInterface
+class DoctrineOrmLoader implements AliceBundleLoaderInterface, LoggerAwareInterface
 {
     use IsAServiceTrait;
 


### PR DESCRIPTION
Removes the `final` keyword from `DoctrineOrmLoader`, allowing it to be extended.