### PR TITLE
docs: change fakerPHP repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ AliceBundle
 ===========
 
 A [Symfony](http://symfony.com) bundle to manage fixtures with [nelmio/alice](https://github.com/nelmio/alice) and
-[fzaninotto/Faker](https://github.com/fzaninotto/Faker).
+[FakerPHP/Faker](https://github.com/FakerPHP/Faker).
 
 The database support is done in [FidryAliceDataFixtures](https://github.com/theofidry/AliceDataFixtures). Check this
 project to know which database/ORM is supported.


### PR DESCRIPTION
The core [```nelmio/alice```](https://github.com/nelmio/alice) changed the Faker dependency from [```fzaninotto/faker```](https://github.com/fzaninotto/faker) to [```fakerphp/faker```](https://github.com/fakerphp/faker).

https://github.com/nelmio/alice/pull/1059